### PR TITLE
Explicitly throw a ParseError if the CODEOWNERS file does not exist

### DIFF
--- a/src/Owners.php
+++ b/src/Owners.php
@@ -91,6 +91,10 @@ final class Owners
      */
     private static function readLinesFrom(string $filename): iterable
     {
+        if (!is_readable($filename)) {
+            throw new ParseException("File {$filename} does not exist or is not readable");
+        }
+
         $file = fopen($filename, 'r');
         if ($file === false) {
             throw new ParseException("Failed to open file: {$filename}");

--- a/tests/OwnersTest.php
+++ b/tests/OwnersTest.php
@@ -225,4 +225,12 @@ class OwnersTest extends TestCase
             $owners->toString()
         );
     }
+
+    public function testParseExceptionIsThrownIfCodeOwnersFileDoesNotExist(): void
+    {
+        $this->assertFileDoesNotExist('/this/file/does/not/exist');
+        $this->expectException(ParseException::class);
+
+        Owners::fromFile('/this/file/does/not/exist');
+    }
 }


### PR DESCRIPTION
Instead of relying on `fopen()` returning false (and triggering an error in the process), check that the given file is readable before attempting to read it.