### PR TITLE
Avoid unbound PHP version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
+    "php": "^7.4 || ^8.0",
     "ext-ctype": "*",
     "symfony/polyfill-php80": "^1.31"
   },


### PR DESCRIPTION
When specifying that the library is compatible with PHP >= 7.4, that means *any* future version: 8.x, 9.x, 100.x, etc.

It's generally better to instead be permissive but avoid claiming compatibility with versions that have yet to be defined. In this PR, the `php` constraint is changed to "PHP 7.4 _or_ anything in the 8.x branch", which is much safer than trying to predict the future.