### PR TITLE
Allow serialization of AutomataMatcher for caching reasons

### DIFF
--- a/src/AutomataMatcher.php
+++ b/src/AutomataMatcher.php
@@ -205,4 +205,26 @@ final class AutomataMatcher implements RuleMatcher
         );
         return ['nodes' => $nodes, 'edges' => $edges];
     }
+
+    /**
+     * @return array{rules: array<Rule>, start: State}
+     */
+    public function __serialize(): array
+    {
+        return [
+            'rules' => $this->rules,
+            'start' => $this->start,
+        ];
+    }
+
+    /**
+     * @param array{rules: array<Rule>, start: State} $data
+     *
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->rules = $data['rules'];
+        $this->start = $data['start'];
+    }
 }

--- a/src/AutomataMatcher/State.php
+++ b/src/AutomataMatcher/State.php
@@ -145,4 +145,28 @@ final class State
             ];
         }
     }
+
+    /**
+     * @return array{priority: int, edges: array<string, State>, isRecursive: bool}
+     */
+    public function __serialize(): array
+    {
+        return [
+            'priority' => $this->priority,
+            'edges' => $this->edges,
+            'isRecursive' => $this->isRecursive,
+        ];
+    }
+
+    /**
+     * @param array{priority: int, edges: array<string, State>, isRecursive: bool} $data
+     *
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->priority = $data['priority'];
+        $this->edges = $data['edges'];
+        $this->isRecursive = $data['isRecursive'];
+    }
 }

--- a/src/Pattern.php
+++ b/src/Pattern.php
@@ -157,4 +157,24 @@ final class Pattern
         $buffer .= '\Z';
         return "#$buffer#";
     }
+
+    /**
+     * @return array{pattern: string}
+     */
+    public function __serialize(): array
+    {
+        return [
+            'pattern' => $this->pattern,
+        ];
+    }
+
+    /**
+     * @param array{pattern: string} $data
+     *
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->pattern = $data['pattern'];
+    }
 }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -180,4 +180,30 @@ final class Rule implements Entry
 
         return $line;
     }
+
+    /**
+     * @return array{pattern: Pattern, owners: array<string>, sourceInfo: SourceInfo, comment: ?string}
+     */
+    public function __serialize(): array
+    {
+        return [
+            'pattern' => $this->pattern,
+            'owners' => $this->owners,
+            'sourceInfo' => $this->sourceInfo,
+            'comment' => $this->comment,
+        ];
+    }
+
+    /**
+     * @param array{pattern: Pattern, owners: array<string>, sourceInfo: SourceInfo, comment: ?string} $data
+     *
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->pattern = $data['pattern'];
+        $this->owners = $data['owners'];
+        $this->sourceInfo = $data['sourceInfo'];
+        $this->comment = $data['comment'];
+    }
 }

--- a/src/SourceInfo.php
+++ b/src/SourceInfo.php
@@ -51,4 +51,26 @@ final class SourceInfo
     {
         return $this->lineNumber;
     }
+
+    /**
+     * @return array{filename: ?string, lineNumber: int}
+     */
+    public function __serialize(): array
+    {
+        return [
+            'filename' => $this->filename,
+            'lineNumber' => $this->lineNumber,
+        ];
+    }
+
+    /**
+     * @param array{filename: ?string, lineNumber: int} $data
+     *
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->filename = $data['filename'];
+        $this->lineNumber = $data['lineNumber'];
+    }
 }

--- a/tests/AutomataMatcherTest.php
+++ b/tests/AutomataMatcherTest.php
@@ -27,6 +27,18 @@ final class AutomataMatcherTest extends TestCase
      * @return iterable<array{AutomataMatcher, string, ?int}>
      * @throws ParseException
      */
+    public static function getSerializedMatchTests(): iterable
+    {
+        return TestProvider::forMatchTests(
+            fn(iterable $rules) => unserialize(serialize(AutomataMatcher::build($rules))),
+            "serialized"
+        );
+    }
+
+    /**
+     * @return iterable<array{AutomataMatcher, string, ?int}>
+     * @throws ParseException
+     */
     public static function getExampleTests(): iterable
     {
         return TestProvider::forExampleTests(
@@ -51,28 +63,10 @@ final class AutomataMatcherTest extends TestCase
      * @return void
      *
      * @dataProvider getMatchTests
-     */
-    public function testMatch(
-        AutomataMatcher $matcher,
-        string $path,
-        ?int $expected_line
-    ): void {
-        $rule = $matcher->match($path);
-        $line = $rule !== null
-            ? $rule->getSourceInfo()->getLineNumber()
-            : null;
-        self::assertSame($expected_line, $line);
-    }
-
-    /**
-     * @param AutomataMatcher $matcher
-     * @param string $path
-     * @param int|null $expected_line
-     * @return void
-     *
+     * @dataProvider getSerializedMatchTests
      * @dataProvider getExampleTests
      */
-    public function testExampleMatch(
+    public function testMatch(
         AutomataMatcher $matcher,
         string $path,
         ?int $expected_line

--- a/tests/SimpleMatcherTest.php
+++ b/tests/SimpleMatcherTest.php
@@ -51,28 +51,9 @@ class SimpleMatcherTest extends TestCase
      * @return void
      *
      * @dataProvider getMatchTests
-     */
-    public function testMatch(
-        SimpleMatcher $matcher,
-        string $path,
-        ?int $expected_line
-    ): void {
-        $rule = $matcher->match($path);
-        $line = $rule !== null
-            ? $rule->getSourceInfo()->getLineNumber()
-            : null;
-        self::assertSame($expected_line, $line);
-    }
-
-    /**
-     * @param SimpleMatcher $matcher
-     * @param string $path
-     * @param int|null $expected_line
-     * @return void
-     *
      * @dataProvider getExampleTests
      */
-    public function testExampleMatch(
+    public function testMatch(
         SimpleMatcher $matcher,
         string $path,
         ?int $expected_line

--- a/tests/TestProvider.php
+++ b/tests/TestProvider.php
@@ -25,7 +25,8 @@ final class TestProvider
      * @throws ParseException
      */
     public static function forMatchTests(
-        Closure $create_matcher
+        Closure $create_matcher,
+        string $unique_identifier = ""
     ): iterable {
         $tests = include __DIR__ . '/matcher_tests.php';
         foreach ($tests as $desc => ['lines' => $lines, 'expected' => $expected]) {
@@ -33,8 +34,12 @@ final class TestProvider
                 implode(PHP_EOL, $lines)
             )->getRules();
             $matcher = $create_matcher($rules);
+            if ($unique_identifier !== "") {
+                $unique_identifier = "{$unique_identifier}: ";
+            }
+
             foreach ($expected as $path => $line) {
-                yield "{$desc} w/ {$path}" => [
+                yield "{$unique_identifier}{$desc} w/ {$path}" => [
                     $matcher,
                     $path,
                     $line
@@ -50,13 +55,18 @@ final class TestProvider
      * @throws ParseException
      */
     public static function forExampleTests(
-        Closure $create_matcher
+        Closure $create_matcher,
+        string $unique_identifier = ""
     ): iterable {
         $owners = Owners::fromFile(__DIR__ . '/CODEOWNERS.example');
         $matcher = $create_matcher($owners->getRules());
         $tests = include __DIR__ . '/example_tests.php';
+        if ($unique_identifier !== "") {
+            $unique_identifier = "{$unique_identifier}: ";
+        }
+
         foreach ($tests as $path => $line) {
-            yield $path => [
+            yield "{$unique_identifier}{$path}" => [
                 $matcher,
                 $path,
                 $line
@@ -70,17 +80,22 @@ final class TestProvider
      * @return iterable<array{T, string, Exception}>
      */
     public static function forBadInputTests(
-        Closure $create_matcher
+        Closure $create_matcher,
+        string $unique_identifier = ""
     ): iterable {
         $matcher = $create_matcher([]);
-        yield 'leading /' => [
+        if ($unique_identifier !== "") {
+            $unique_identifier = "{$unique_identifier}: ";
+        }
+
+        yield "{$unique_identifier}leading /" => [
             $matcher,
             '/foo/bar',
             new InvalidArgumentException(
                 "path should be a relative path to a file, thus it cannot start or end with a /"
             )
         ];
-        yield 'trailing /' => [
+        yield "{$unique_identifier}trailing /" => [
             $matcher,
             'foo/bar/',
             new InvalidArgumentException(


### PR DESCRIPTION
For large rulesets, caching of the matcher can provide a nice speed boost. To facilitate that, I implemented serialization, and then clients can cache however they want.

For tests, I collapsed some of them together with multiple data providers, but added an optional param for `unique_identifier` to all the providers so that they don't step on each other if you call the same provider twice in one set of tests.